### PR TITLE
initial spike of ARIES-1038 so that blueprint-noosgi can be easily used ...

### DIFF
--- a/blueprint/blueprint-sample-war/pom.xml
+++ b/blueprint/blueprint-sample-war/pom.xml
@@ -47,6 +47,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-servlet_2.5_spec</artifactId>
+            <version>1.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.aries.blueprint</groupId>
             <artifactId>org.apache.aries.blueprint.web</artifactId>
             <version>${blueprint.web.version}</version>

--- a/blueprint/blueprint-web/pom.xml
+++ b/blueprint/blueprint-web/pom.xml
@@ -63,6 +63,7 @@
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-servlet_2.5_spec</artifactId>
             <version>1.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/blueprint/blueprint-web/src/main/java/org/apache/aries/blueprint/web/BlueprintContextListener.java
+++ b/blueprint/blueprint-web/src/main/java/org/apache/aries/blueprint/web/BlueprintContextListener.java
@@ -45,8 +45,7 @@ public class BlueprintContextListener implements ServletContextListener {
         if (location == null) {
             location = DEFAULT_LOCATION;
         }
-        Set<URL> resourcePathSet = servletContext.getResourcePaths(location);
-        List<URL> resourcePaths = new ArrayList<URL>(resourcePathSet);
+        List<URL> resourcePaths = new ArrayList<URL>();
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         try {
             Enumeration<URL> resources = classLoader.getResources(location);


### PR DESCRIPTION
...inside a servlet engine without an OSGi environment; but booting up all the META-INF/blueprint.xml files and performing the DI on everything using blueprint-noosgi
