### PR TITLE
Please merge fix for ARIES-1078

### DIFF
--- a/jpa/jpa-container/src/main/java/org/apache/aries/jpa/container/impl/PersistenceBundleManager.java
+++ b/jpa/jpa-container/src/main/java/org/apache/aries/jpa/container/impl/PersistenceBundleManager.java
@@ -177,7 +177,7 @@ public class PersistenceBundleManager implements BundleTrackerCustomizer, Servic
       while(it.hasNext()) {
         EntityManagerFactoryManager mgr = it.next();
         ServiceReference reference = getProviderServiceReference(mgr.getParsedPersistenceUnits());
-        if(ref != null) {
+        if(reference != null) {
           managersToManage.put(mgr, reference);
           it.remove();
         }


### PR DESCRIPTION
ARIES-1078 : Fix for provider registration listener, which stops waiting after one provider is found, instead of waiting for the target provider.
