### PR TITLE
[ARIES-1167] use ExtraOption, not CoreOption for mavenBundle()

### DIFF
--- a/transaction/transaction-itests/src/test/java/org/apache/aries/transaction/itests/AbstractIntegrationTest.java
+++ b/transaction/transaction-itests/src/test/java/org/apache/aries/transaction/itests/AbstractIntegrationTest.java
@@ -20,7 +20,6 @@ package org.apache.aries.transaction.itests;
 
 import static org.ops4j.pax.exam.CoreOptions.bootDelegationPackages;
 import static org.ops4j.pax.exam.CoreOptions.equinox;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.systemProperty;
 import static org.ops4j.pax.exam.container.def.PaxRunnerOptions.vmOption;
 


### PR DESCRIPTION
ExtraOption.mavenBundle() adds `versionAsInProject()` to bundle. CoreOption.mavenBundle - doesn't.
