### PR TITLE
ARIES-1047 Upgrade to JPA 2.1

### DIFF
--- a/jpa/jpa-api/pom.xml
+++ b/jpa/jpa-api/pom.xml
@@ -46,8 +46,8 @@
             org.apache.aries.jpa.container.context
         </aries.osgi.export.pkg>
         <aries.osgi.import>
-             javax.persistence;version="[1.0.0,2.1.0)",
-             javax.persistence.spi;version="[1.0.0,2.1.0)",
+             javax.persistence;version="[1.0.0,3.0.0)",
+             javax.persistence.spi;version="[1.0.0,3.0.0)",
              org.osgi.framework;version="[1.5.0,2.0.0)"
         </aries.osgi.import>
         <aries.osgi.private.pkg />
@@ -60,8 +60,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jpa_2.0_spec</artifactId>
-            <version>1.1</version>
+            <artifactId>geronimo-jpa_2.1_spec</artifactId>
+            <version>1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/jpa/jpa-blueprint-aries/pom.xml
+++ b/jpa/jpa-blueprint-aries/pom.xml
@@ -60,8 +60,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jpa_2.0_spec</artifactId>
-            <version>1.1</version>
+            <artifactId>geronimo-jpa_2.1_spec</artifactId>
+            <version>1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.apache.aries.jpa</groupId>
             <artifactId>org.apache.aries.jpa.api</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/jpa/jpa-blueprint-testbundle/pom.xml
+++ b/jpa/jpa-blueprint-testbundle/pom.xml
@@ -52,8 +52,8 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jpa_2.0_spec</artifactId>
-            <version>1.1</version>
+            <artifactId>geronimo-jpa_2.1_spec</artifactId>
+            <version>1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/jpa/jpa-container-advancedtestbundle/pom.xml
+++ b/jpa/jpa-container-advancedtestbundle/pom.xml
@@ -44,7 +44,7 @@
             org.apache.aries.jpa.container.advanced.itest.bundle.entities
         </aries.osgi.export.pkg>
         <aries.osgi.import>
-            javax.persistence;version="[1.0.0,2.0.0)",
+            javax.persistence;version="[1.0.0,3.0.0)",
             org.apache.derby.jdbc,
             *
         </aries.osgi.import>
@@ -54,8 +54,8 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jpa_2.0_spec</artifactId>
-            <version>1.1</version>
+            <artifactId>geronimo-jpa_2.1_spec</artifactId>
+            <version>1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/jpa/jpa-container-context/pom.xml
+++ b/jpa/jpa-container-context/pom.xml
@@ -43,9 +43,9 @@
 
         <aries.osgi.export.pkg />
         <aries.osgi.import>
-            javax.persistence;version="[1.0.0,2.1.0)",
-            javax.persistence.criteria;version="[1.1.0,2.1.0)";resolution:=optional,
-            javax.persistence.metamodel;version="[1.1.0,2.1.0)";resolution:=optional,
+            javax.persistence;version="[1.0.0,3.0.0)",
+            javax.persistence.criteria;version="[1.1.0,3.0.0)";resolution:=optional,
+            javax.persistence.metamodel;version="[1.1.0,3.0.0)";resolution:=optional,
             org.apache.aries.jpa.container.context;provide:=true,
             org.apache.aries.quiesce.manager;provide:=true;resolution:=optional,
             org.apache.aries.quiesce.participant;provide:=true;resolution:=optional,
@@ -70,8 +70,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jpa_2.0_spec</artifactId>
-            <version>1.1</version>
+            <artifactId>geronimo-jpa_2.1_spec</artifactId>
+            <version>1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.apache.aries.jpa</groupId>
             <artifactId>org.apache.aries.jpa.api</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jpa/jpa-container-context/src/main/java/org/apache/aries/jpa/container/context/impl/ManagedPersistenceContextFactory.java
+++ b/jpa/jpa-container-context/src/main/java/org/apache/aries/jpa/container/context/impl/ManagedPersistenceContextFactory.java
@@ -22,15 +22,10 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.persistence.Cache;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.PersistenceContextType;
-import javax.persistence.PersistenceUnitUtil;
+import javax.persistence.*;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.metamodel.Metamodel;
 
@@ -138,6 +133,26 @@ public class ManagedPersistenceContextFactory implements EntityManagerFactory, D
     if(activeCount.get() == 0) {
       tidyUp.unitQuiesced(unitName);
     }
+  }
+
+  public <T> void addNamedEntityGraph(String arg0, EntityGraph<T> arg1) {
+      throw new UnsupportedOperationException();
+  }
+
+  public void addNamedQuery(String arg0, Query arg1) {
+      throw new UnsupportedOperationException();
+  }
+
+  public EntityManager createEntityManager(SynchronizationType arg0) {
+      return null;
+  }
+
+  public EntityManager createEntityManager(SynchronizationType arg0, Map arg1) {
+      return null;
+  }
+
+  public <T> T unwrap(Class<T> arg0) {
+      return null;
   }
 
   /**

--- a/jpa/jpa-container-context/src/main/java/org/apache/aries/jpa/container/context/transaction/impl/JTAEntityManager.java
+++ b/jpa/jpa-container-context/src/main/java/org/apache/aries/jpa/container/context/transaction/impl/JTAEntityManager.java
@@ -18,19 +18,15 @@
  */
 package org.apache.aries.jpa.container.context.transaction.impl;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.EntityTransaction;
-import javax.persistence.FlushModeType;
-import javax.persistence.LockModeType;
-import javax.persistence.Query;
-import javax.persistence.TransactionRequiredException;
-import javax.persistence.TypedQuery;
+import javax.persistence.*;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaDelete;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaUpdate;
 import javax.persistence.metamodel.Metamodel;
 
 import org.apache.aries.jpa.container.context.impl.NLS;
@@ -254,6 +250,10 @@ public class JTAEntityManager implements EntityManager {
     //This should be a no-op for a JTA entity manager
   }
 
+  public boolean isJoinedToTransaction() {
+      return true;
+  }
+
   /**
    * @throws TransactionRequiredException
    */
@@ -327,6 +327,50 @@ public class JTAEntityManager implements EntityManager {
     }
   }
 
+  public StoredProcedureQuery createStoredProcedureQuery(String arg0) {
+      EntityManager em = getPersistenceContext(false);
+      try {
+          return em.createStoredProcedureQuery(arg0);
+      } finally {
+          if (em == detachedManager) {
+              em.clear();
+          }
+      }
+  }
+
+  public StoredProcedureQuery createStoredProcedureQuery(String arg0, Class ... arg1) {
+      EntityManager em = getPersistenceContext(false);
+      try {
+          return em.createStoredProcedureQuery(arg0, arg1);
+      } finally {
+          if (em == detachedManager) {
+              em.clear();
+          }
+      }
+  }
+
+  public StoredProcedureQuery createStoredProcedureQuery(String arg0, String ... arg1) {
+      EntityManager em = getPersistenceContext(false);
+      try {
+          return em.createStoredProcedureQuery(arg0, arg1);
+      } finally {
+          if (em == detachedManager) {
+              em.clear();
+          }
+      }
+  }
+
+  public StoredProcedureQuery createNamedStoredProcedureQuery(String arg0) {
+      EntityManager em = getPersistenceContext(false);
+      try {
+          return em.createNamedStoredProcedureQuery(arg0);
+      } finally {
+          if (em == detachedManager) {
+              em.clear();
+          }
+      }
+  }
+
   public <T> TypedQuery<T> createQuery(String arg0, Class<T> arg1)
   {
     EntityManager em = getPersistenceContext(false);
@@ -336,6 +380,28 @@ public class JTAEntityManager implements EntityManager {
       if(em == detachedManager)
         em.clear();
     }
+  }
+
+  public Query createQuery(CriteriaUpdate arg0) {
+      EntityManager em = getPersistenceContext(false);
+      try {
+          return em.createQuery(arg0);
+      } finally {
+          if (em == detachedManager) {
+              em.clear();
+          }
+      }
+  }
+
+  public Query createQuery(CriteriaDelete arg0) {
+      EntityManager em = getPersistenceContext(false);
+      try {
+          return em.createQuery(arg0);
+      } finally {
+          if (em == detachedManager) {
+              em.clear();
+          }
+      }
   }
 
   public void detach(Object arg0)
@@ -467,4 +533,45 @@ public class JTAEntityManager implements EntityManager {
         em.clear();
     }
   }
+
+  public <T> EntityGraph<T> createEntityGraph(Class<T> arg0) {
+      EntityManager em = getPersistenceContext(false);
+      try {
+          return em.createEntityGraph(arg0);
+      } finally {
+          if (em == detachedManager)
+              em.clear();
+      }
+  }
+
+  public EntityGraph<?> createEntityGraph(String arg0) {
+      EntityManager em = getPersistenceContext(false);
+      try {
+          return em.createEntityGraph(arg0);
+      } finally {
+          if (em == detachedManager)
+              em.clear();
+      }
+  }
+
+  public EntityGraph<?> getEntityGraph(String arg0) {
+      EntityManager em = getPersistenceContext(false);
+      try {
+          return em.getEntityGraph(arg0);
+      } finally {
+          if (em == detachedManager)
+              em.clear();
+      }
+  }
+
+  public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> arg0) {
+      EntityManager em = getPersistenceContext(false);
+      try {
+          return em.getEntityGraphs(arg0);
+      } finally {
+          if (em == detachedManager)
+              em.clear();
+      }
+  }
+
 }

--- a/jpa/jpa-container-context/src/main/java/org/apache/aries/jpa/container/context/transaction/impl/SynchronizedEntityManagerWrapper.java
+++ b/jpa/jpa-container-context/src/main/java/org/apache/aries/jpa/container/context/transaction/impl/SynchronizedEntityManagerWrapper.java
@@ -18,16 +18,13 @@
  */
 package org.apache.aries.jpa.container.context.transaction.impl;
 
+import java.util.List;
 import java.util.Map;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.EntityTransaction;
-import javax.persistence.FlushModeType;
-import javax.persistence.LockModeType;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
+import javax.persistence.*;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaDelete;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaUpdate;
 import javax.persistence.metamodel.Metamodel;
 
 /**
@@ -145,12 +142,36 @@ public class SynchronizedEntityManagerWrapper implements EntityManager {
         return entityManager.createQuery(qlString, resultClass);
     }
 
+    public Query createQuery(CriteriaUpdate arg0) {
+        return entityManager.createQuery(arg0);
+    }
+
+    public Query createQuery(CriteriaDelete arg0) {
+        return entityManager.createQuery(arg0);
+    }
+
     public synchronized Query createNamedQuery(String name) {
         return entityManager.createNamedQuery(name);
     }
 
     public synchronized <T> TypedQuery<T> createNamedQuery(String name, Class<T> resultClass) {
         return entityManager.createNamedQuery(name, resultClass);
+    }
+
+    public StoredProcedureQuery createNamedStoredProcedureQuery(String arg0) {
+        return entityManager.createNamedStoredProcedureQuery(arg0);
+    }
+
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0) {
+        return entityManager.createStoredProcedureQuery(arg0);
+    }
+
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0, Class ... arg1) {
+        return entityManager.createStoredProcedureQuery(arg0, arg1);
+    }
+
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0, String ... arg1) {
+        return entityManager.createStoredProcedureQuery(arg0, arg1);
     }
 
     public synchronized Query createNativeQuery(String sqlString) {
@@ -167,6 +188,10 @@ public class SynchronizedEntityManagerWrapper implements EntityManager {
 
     public synchronized void joinTransaction() {
         entityManager.joinTransaction();
+    }
+
+    public boolean isJoinedToTransaction() {
+        return entityManager.isJoinedToTransaction();
     }
 
     public synchronized <T> T unwrap(Class<T> cls) {
@@ -200,4 +225,21 @@ public class SynchronizedEntityManagerWrapper implements EntityManager {
     public synchronized Metamodel getMetamodel() {
         return entityManager.getMetamodel();
     }
+
+    public <T> EntityGraph<T> createEntityGraph(Class<T> arg0) {
+        return entityManager.createEntityGraph(arg0);
+    }
+
+    public EntityGraph<?> createEntityGraph(String arg0) {
+        return entityManager.createEntityGraph(arg0);
+    }
+
+    public EntityGraph<?> getEntityGraph(String arg0) {
+        return entityManager.getEntityGraph(arg0);
+    }
+
+    public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> arg0) {
+        return entityManager.getEntityGraphs(arg0);
+    }
+
 }

--- a/jpa/jpa-container-eclipselink-adapter/pom.xml
+++ b/jpa/jpa-container-eclipselink-adapter/pom.xml
@@ -37,7 +37,7 @@
     <aries.osgi.private.pkg>org.apache.aries.jpa.eclipselink.adapter.*</aries.osgi.private.pkg>
     <aries.osgi.export.pkg></aries.osgi.export.pkg>
     <aries.osgi.import.pkg>
-      javax.persistence*;version="[1.1,2.1)",
+      javax.persistence*;version="[1.1,3.0.0)",
       !org.eclipse.persistence.*,
       *
     </aries.osgi.import.pkg>
@@ -63,8 +63,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-jpa_2.0_spec</artifactId>
-      <version>1.1</version>
+      <artifactId>geronimo-jpa_2.1_spec</artifactId>
+      <version>1.0-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/jpa/jpa-container-itest/pom.xml
+++ b/jpa/jpa-container-itest/pom.xml
@@ -147,8 +147,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jpa_2.0_spec</artifactId>
-            <version>1.1</version>
+            <artifactId>geronimo-jpa_2.1_spec</artifactId>
+            <version>1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jpa/jpa-container-testbundle/pom.xml
+++ b/jpa/jpa-container-testbundle/pom.xml
@@ -53,8 +53,8 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jpa_2.0_spec</artifactId>
-            <version>1.1</version>
+            <artifactId>geronimo-jpa_2.1_spec</artifactId>
+            <version>1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jpa/jpa-container/pom.xml
+++ b/jpa/jpa-container/pom.xml
@@ -42,10 +42,10 @@
 
         <aries.osgi.export.pkg />
         <aries.osgi.import>
-            javax.persistence;version="[1.0.0,2.1.0)",
-            javax.persistence.spi;version="[1.0.0,2.1.0)",
-            javax.persistence.criteria;version="[1.1.0,2.1.0)";resolution:=optional,
-            javax.persistence.metamodel;version="[1.1.0,2.1.0)";resolution:=optional,
+            javax.persistence;version="[1.0.0,3.0.0)",
+            javax.persistence.spi;version="[1.0.0,3.0.0)",
+            javax.persistence.criteria;version="[1.1.0,3.0.0)";resolution:=optional,
+            javax.persistence.metamodel;version="[1.1.0,3.0.0)";resolution:=optional,
             !javax.transaction,
             org.apache.aries.jpa.container*;provide:=true,
             org.apache.aries.quiesce.manager;provide:=true;resolution:=optional,
@@ -84,7 +84,7 @@
         <dependency>
             <artifactId>org.apache.aries.jpa.api</artifactId>
             <groupId>org.apache.aries.jpa</groupId>
-            <version>1.0.0</version>
+            <version>1.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.aries.quiesce</groupId>
@@ -100,8 +100,8 @@
             </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jpa_2.0_spec</artifactId>
-            <version>1.1</version>
+            <artifactId>geronimo-jpa_2.1_spec</artifactId>
+            <version>1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jpa/jpa-container/src/main/java/org/apache/aries/jpa/container/impl/CountingEntityManagerFactory.java
+++ b/jpa/jpa-container/src/main/java/org/apache/aries/jpa/container/impl/CountingEntityManagerFactory.java
@@ -23,10 +23,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.persistence.Cache;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.PersistenceUnitUtil;
+import javax.persistence.*;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.metamodel.Metamodel;
 
@@ -127,6 +124,26 @@ public class CountingEntityManagerFactory implements EntityManagerFactory, Destr
     if(c != null) {
       c.callback(name);
     }
+  }
+
+  public <T> void addNamedEntityGraph(String arg0, EntityGraph<T> arg1) {
+      delegate.addNamedEntityGraph(arg0, arg1);
+  }
+
+  public void addNamedQuery(String arg0, Query arg1) {
+      delegate.addNamedQuery(arg0, arg1);
+  }
+
+  public EntityManager createEntityManager(SynchronizationType arg0) {
+      return delegate.createEntityManager(arg0);
+  }
+
+  public EntityManager createEntityManager(SynchronizationType arg0, Map arg1) {
+      return delegate.createEntityManager(arg0, arg1);
+  }
+
+  public <T> T unwrap(Class<T> arg0) {
+      return delegate.unwrap(arg0);
   }
 
 }

--- a/jpa/jpa-container/src/main/java/org/apache/aries/jpa/container/impl/EntityManagerWrapper.java
+++ b/jpa/jpa-container/src/main/java/org/apache/aries/jpa/container/impl/EntityManagerWrapper.java
@@ -18,17 +18,14 @@
  */
 package org.apache.aries.jpa.container.impl;
 
+import java.util.List;
 import java.util.Map;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.EntityTransaction;
-import javax.persistence.FlushModeType;
-import javax.persistence.LockModeType;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
+import javax.persistence.*;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaDelete;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaUpdate;
 import javax.persistence.metamodel.Metamodel;
 
 /**
@@ -68,6 +65,14 @@ public class EntityManagerWrapper implements EntityManager {
     return delegate.createNamedQuery(arg0);
   }
 
+  public StoredProcedureQuery createNamedStoredProcedureQuery(String arg0) { return delegate.createNamedStoredProcedureQuery(arg0); }
+
+  public StoredProcedureQuery createStoredProcedureQuery(String arg0) { return delegate.createStoredProcedureQuery(arg0); }
+
+  public StoredProcedureQuery createStoredProcedureQuery(String arg0, Class ... arg1) { return delegate.createStoredProcedureQuery(arg0, arg1); }
+
+  public StoredProcedureQuery createStoredProcedureQuery(String arg0, String ... arg1) { return delegate.createStoredProcedureQuery(arg0, arg1); }
+
   public Query createNativeQuery(String arg0, Class arg1) {
     return delegate.createNativeQuery(arg0, arg1);
   }
@@ -91,6 +96,10 @@ public class EntityManagerWrapper implements EntityManager {
   public Query createQuery(String arg0) {
     return delegate.createQuery(arg0);
   }
+
+  public Query createQuery(CriteriaUpdate arg0) { return delegate.createQuery(arg0); }
+
+  public Query createQuery(CriteriaDelete arg0) { return delegate.createQuery(arg0); }
 
   public void detach(Object arg0) {
     delegate.detach(arg0);
@@ -161,6 +170,8 @@ public class EntityManagerWrapper implements EntityManager {
     delegate.joinTransaction();
   }
 
+  public boolean isJoinedToTransaction() { return delegate.isJoinedToTransaction(); }
+
   public void lock(Object arg0, LockModeType arg1, Map<String, Object> arg2) {
     delegate.lock(arg0, arg1, arg2);
   }
@@ -208,4 +219,13 @@ public class EntityManagerWrapper implements EntityManager {
   public <T> T unwrap(Class<T> arg0) {
     return delegate.unwrap(arg0);
   }
+
+  public <T> EntityGraph<T> createEntityGraph(Class<T> arg0) { return delegate.createEntityGraph(arg0); }
+
+  public EntityGraph<?> createEntityGraph(String arg0) { return delegate.createEntityGraph(arg0); }
+
+  public EntityGraph<?> getEntityGraph(String arg0) { return delegate.getEntityGraph(arg0); }
+
+  public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> arg0) { return delegate.getEntityGraphs(arg0); }
+
 }


### PR DESCRIPTION
Add JPA 2.1 support using geronimo-jpa_2.1.

NB: for now, this pull request uses geronimo-jpa_2.1 1.0-SNAPSHOT waiting for the released version.
