### PR TITLE
Update pom.xml to use an bundle existent at maven central

### DIFF
--- a/subsystem/subsystem-itests/pom.xml
+++ b/subsystem/subsystem-itests/pom.xml
@@ -297,7 +297,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.eclipse</groupId>
+            <groupId>org.eclipse.tycho</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <version>3.10.0.v20140606-1445</version>
         </dependency>


### PR DESCRIPTION
at maven central there are no bundle with GAV org.eclipse:org.eclipse.osgi:3.10.0.v20140606-1445
