### PR TITLE
ARIES-628 fix transaction itests

### DIFF
--- a/transaction/transaction-itests/pom.xml
+++ b/transaction/transaction-itests/pom.xml
@@ -72,7 +72,7 @@
             <groupId>org.apache.aries.transaction</groupId>
             <artifactId>org.apache.aries.transaction.blueprint</artifactId>
             <scope>test</scope>
-            <version>1.0.3-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.aries.transaction</groupId>


### PR DESCRIPTION
use right version of org.apache.aries.transaction.blueprint to fix transaction itests after commit 70e39b6
