### PR TITLE
[aries-1612] Zip input stream relies on default (non buffered) InputS…

### DIFF
--- a/util/util-r42/src/main/java/org/apache/aries/util/filesystem/impl/ZipFileImpl.java
+++ b/util/util-r42/src/main/java/org/apache/aries/util/filesystem/impl/ZipFileImpl.java
@@ -290,6 +290,16 @@ public class ZipFileImpl implements IFile
     }
 
     @Override
+    public int read(byte[] b) throws IOException {
+      return is.read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      return is.read(b, off, len);
+    }
+
+    @Override
     public int read() throws IOException
     {
       return is.read();


### PR DESCRIPTION
Fix of the [[aries-1612]](https://issues.apache.org/jira/browse/ARIES-1612) issue.
