### PR TITLE
ARIES-1634 BlueprintContainer are leaked when destroyed

### DIFF
--- a/blueprint/blueprint-core/src/main/java/org/apache/aries/blueprint/container/BlueprintContainerImpl.java
+++ b/blueprint/blueprint-core/src/main/java/org/apache/aries/blueprint/container/BlueprintContainerImpl.java
@@ -894,6 +894,9 @@ public class BlueprintContainerImpl
         cancelFutureIfPresent();
 
         eventDispatcher.blueprintEvent(new BlueprintEvent(BlueprintEvent.DESTROYING, getBundle(), getExtenderBundle()));
+
+        AriesFrameworkUtil.safeUnregisterService(registration);
+
         executors.shutdownNow();
         if (handlerSet != null) {
             handlerSet.removeListener(this);


### PR DESCRIPTION
While destroying the BlueprintContainer, the associated
ServiceRegistration isn't unregistered, although it should
be to completely release the BlueprintContainer.

The #quiesce() method does that correctly, so current workaround
is to first quiesce the bundle then destroy it. But it feels like
an oversight in the #destroy() method.

Signed-off-by: Alexis de Talhouët <adetalhouet@inocybe.com>