### PR TITLE
[ARIES-1636] mvn install fails due to old dependency versions

### DIFF
--- a/blueprint/blueprint-itests/pom.xml
+++ b/blueprint/blueprint-itests/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.apache.aries.blueprint</groupId>
             <artifactId>org.apache.aries.blueprint.core</artifactId>
-            <version>1.7.1-SNAPSHOT</version>
+            <version>1.7.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.aries.blueprint</groupId>

--- a/blueprint/blueprint-spring-extender/pom.xml
+++ b/blueprint/blueprint-spring-extender/pom.xml
@@ -71,7 +71,7 @@
             <id>dev</id>
             <properties>
                 <blueprint.api.version>1.0.1</blueprint.api.version>
-                <blueprint.core.version>1.7.1-SNAPSHOT</blueprint.core.version>
+                <blueprint.core.version>1.7.2-SNAPSHOT</blueprint.core.version>
                 <blueprint.parser.version>1.5.0-SNAPSHOT</blueprint.parser.version>
             </properties>
         </profile>

--- a/blueprint/blueprint-spring/pom.xml
+++ b/blueprint/blueprint-spring/pom.xml
@@ -71,7 +71,7 @@
             <id>dev</id>
             <properties>
                 <blueprint.api.version>1.0.1</blueprint.api.version>
-                <blueprint.core.version>1.7.1-SNAPSHOT</blueprint.core.version>
+                <blueprint.core.version>1.7.2-SNAPSHOT</blueprint.core.version>
                 <blueprint.parser.version>1.5.0-SNAPSHOT</blueprint.parser.version>
             </properties>
         </profile>

--- a/blueprint/blueprint-web-osgi/pom.xml
+++ b/blueprint/blueprint-web-osgi/pom.xml
@@ -61,7 +61,7 @@
         <profile>
             <id>dev</id>
             <properties>
-                <blueprint.core.version>1.3.1-SNAPSHOT</blueprint.core.version>
+                <blueprint.core.version>1.3.2-SNAPSHOT</blueprint.core.version>
             </properties>
         </profile>
     </profiles> 

--- a/samples/blueprint/helloworld/helloworld-itests/pom.xml
+++ b/samples/blueprint/helloworld/helloworld-itests/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>org.ops4j.pax.swissbox</groupId>
             <artifactId>pax-swissbox-tinybundles</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.2</version>
         </dependency>
 
         <dependency>

--- a/transaction/transaction-itests/pom.xml
+++ b/transaction/transaction-itests/pom.xml
@@ -127,7 +127,7 @@
             <groupId>org.apache.aries.transaction</groupId>
             <artifactId>org.apache.aries.transaction.manager</artifactId>
             <scope>test</scope>
-            <version>1.3.1-SNAPSHOT</version>
+            <version>1.3.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.aries.transaction</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARIES-1636

Updated Aries blueprint snapshot versions and pax-swissbox-tinybundles version. Thanks!