### PR TITLE
Support variable as argument for ServiceLoader.load.

### DIFF
--- a/spi-fly/spi-fly-dynamic-bundle/src/test/java/org/apache/aries/spifly/dynamic/TestClient.java
+++ b/spi-fly/spi-fly-dynamic-bundle/src/test/java/org/apache/aries/spifly/dynamic/TestClient.java
@@ -25,10 +25,30 @@ import java.util.Set;
 import org.apache.aries.mytest.MySPI;
 
 public class TestClient {
+	/**
+	 * Load using a constant as parameter.
+	 */
     public Set<String> test(String input) {
         Set<String> results = new HashSet<String>();
 
         ServiceLoader<MySPI> loader = ServiceLoader.load(MySPI.class);
+        for (MySPI mySPI : loader) {
+            results.add(mySPI.someMethod(input));
+        }
+        return results;
+    }
+    
+	/**
+	 * Load using a variable as parameter.
+	 */
+    public Set<String> testService(String input, Class<MySPI> service) {
+        Set<String> results = new HashSet<String>();
+
+        // Try to irritate TCCLSetterVisitor by forcing an (irrelevant) LDC.
+        @SuppressWarnings("unused")
+		Class<?> causeLDC = String.class;
+        
+        ServiceLoader<MySPI> loader = ServiceLoader.load(service);
         for (MySPI mySPI : loader) {
             results.add(mySPI.someMethod(input));
         }


### PR DESCRIPTION
Fixes [#1321](https://issues.apache.org/jira/browse/ARIES-1321). (Took me *hours* to find out that the problem wasn't my configuration of osgi.serviceloader but a critical(!) bug in the implementation opened 2.5 years ago.) The fix is based on [Olivier Nouguier](https://issues.apache.org/jira/secure/ViewProfile.jspa?name=cheleb)'s patch. I improved it a bit to handle an additional possible problem and added test cases.