### PR TITLE
[ARIES-1849] do not use invokevirtual for interface default methods

### DIFF
--- a/proxy/proxy-impl/src/main/java/org/apache/aries/proxy/impl/common/AbstractWovenProxyMethodAdapter.java
+++ b/proxy/proxy-impl/src/main/java/org/apache/aries/proxy/impl/common/AbstractWovenProxyMethodAdapter.java
@@ -227,7 +227,7 @@ public abstract class AbstractWovenProxyMethodAdapter extends GeneratorAdapter
     loadLocal(dispatchTarget);
     checkCast(methodDeclaringType);
     loadArgs();
-    if(isMethodDeclaringTypeInterface && !isDefaultMethod) {
+    if(isMethodDeclaringTypeInterface) {
       invokeInterface(methodDeclaringType, currentTransformMethod);
     } else {
       invokeVirtual(methodDeclaringType, currentTransformMethod);


### PR DESCRIPTION
A default method is still an interface method, hence we should use invokeinterface, not invokevirtual, otherwise we will get an IncompatibleClassChangeError from hotspot.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>