### PR TITLE
ARIES-1934 - Make sure jar/zip files are jailed to the destination di…

### DIFF
--- a/spi-fly/spi-fly-static-tool/src/main/java/org/apache/aries/spifly/statictool/Main.java
+++ b/spi-fly/spi-fly-static-tool/src/main/java/org/apache/aries/spifly/statictool/Main.java
@@ -243,14 +243,17 @@ public class Main {
         JarInputStream jis = new JarInputStream(new FileInputStream(jarFile));
         JarEntry je = null;
         while((je = jis.getNextJarEntry()) != null) {
+            File outFile = new File(tempDir, je.getName());
+            if (!outFile.getCanonicalPath().startsWith(tempDir.getCanonicalPath())) {
+                throw new IOException("The output file is not contained in the destination directory");
+            }
+
             if (je.isDirectory()) {
-                File outDir = new File(tempDir, je.getName());
-                ensureDirectory(outDir);
+                ensureDirectory(outFile);
 
                 continue;
             }
 
-            File outFile = new File(tempDir, je.getName());
             File outDir = outFile.getParentFile();
             ensureDirectory(outDir);
 

--- a/util/src/main/java/org/apache/aries/util/io/IOUtils.java
+++ b/util/src/main/java/org/apache/aries/util/io/IOUtils.java
@@ -274,7 +274,12 @@ public class IOUtils
         isZip = false;                             // It's not a zip - that's ok, we'll return that below. 
       }
       if(isZip){
-        do { 
+        do {
+          File outFile = new File(outputDir, zipEntry.getName());
+          if (!outFile.getCanonicalPath().startsWith(outputDir.getCanonicalPath())) {
+            throw new IOException("The output file is not contained in the destination directory");
+          }
+
           if (!zipEntry.isDirectory()) { 
             writeOutAndDontCloseInputStream(outputDir, zipEntry.getName(), zis);
           }


### PR DESCRIPTION
…rectory

There are a number of locations in Aries where we unzip a jar or zip file to the filesystem, without checking that the all of the files are jailed to the intended destination directory. This is a potential security issue as it allows an attacked to overwrite files on the system outside of the intended directory.