### PR TITLE
Switch to using a more recent version of commons-io

### DIFF
--- a/proxy/proxy-impl/pom.xml
+++ b/proxy/proxy-impl/pom.xml
@@ -102,9 +102,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
+            <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.3.2</version>
+            <version>2.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Even though it's just a test dependency, we're pulling in an old version of commons-io with known security vulnerabilities - better to upgrade.