### PR TITLE
ARIES-2046 Adding support for blacklisting namespace handlers

### DIFF
--- a/blueprint/blueprint-spring/src/main/java/org/apache/aries/blueprint/spring/Activator.java
+++ b/blueprint/blueprint-spring/src/main/java/org/apache/aries/blueprint/spring/Activator.java
@@ -18,11 +18,12 @@ package org.apache.aries.blueprint.spring;
 
 import java.net.URL;
 
-import org.apache.aries.blueprint.NamespaceHandler;
 import org.apache.felix.utils.extender.AbstractExtender;
 import org.apache.felix.utils.extender.Extension;
 import org.osgi.framework.Bundle;
-import org.osgi.framework.ServiceRegistration;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,16 +34,23 @@ import org.slf4j.LoggerFactory;
  * @see SpringExtension
  */
 public class Activator extends AbstractExtender {
-
+    public static final String SPRING_NAMESPACE_BLACKLIST_PID = "org.apache.karaf.blueprint.spring.namespace.handler.blacklist";
     private static final Logger LOGGER = LoggerFactory.getLogger(Activator.class);
 
-    ServiceRegistration<NamespaceHandler> registration;
+    private Configuration blacklistedNamespaces;
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        ConfigurationAdmin configAdmin = context.getService(context.getServiceReference(ConfigurationAdmin.class));
+        blacklistedNamespaces = configAdmin.getConfiguration(SPRING_NAMESPACE_BLACKLIST_PID);
+        super.start(context);
+    }
 
     @Override
     protected Extension doCreateExtension(Bundle bundle) throws Exception {
         URL handlers = bundle.getResource(SpringExtension.SPRING_HANDLERS);
         if (handlers != null) {
-            return new SpringExtension(bundle);
+            return new SpringExtension(bundle, blacklistedNamespaces);
         }
         return null;
     }

--- a/blueprint/itests/blueprint-itests/pom.xml
+++ b/blueprint/itests/blueprint-itests/pom.xml
@@ -228,6 +228,12 @@
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-cm</artifactId>
+            <version>${exam.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-junit4</artifactId>
             <version>${exam.version}</version>
             <scope>test</scope>
@@ -346,6 +352,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/blueprint/itests/blueprint-itests/src/test/java/org/apache/aries/blueprint/itests/SpringTest.java
+++ b/blueprint/itests/blueprint-itests/src/test/java/org/apache/aries/blueprint/itests/SpringTest.java
@@ -18,9 +18,10 @@
  */
 package org.apache.aries.blueprint.itests;
 
+import java.util.Arrays;
 import java.util.List;
 
-import org.apache.aries.blueprint.testbundles.BeanC;
+import org.apache.aries.blueprint.spring.Activator;
 import org.apache.aries.blueprint.testbundles.BeanCItf;
 import org.junit.Test;
 import org.ops4j.pax.exam.Option;
@@ -29,10 +30,9 @@ import org.osgi.service.blueprint.container.BlueprintContainer;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
 import static org.apache.aries.blueprint.itests.Helper.mvnBundle;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.newConfiguration;
 
 public class SpringTest extends AbstractBlueprintIntegrationTest {
 
@@ -57,11 +57,25 @@ public class SpringTest extends AbstractBlueprintIntegrationTest {
         }
     }
 
+    @Test
+    public void testSpringNsHandlerBlacklist() throws Exception {
+        Bundle bundles = context().getBundleByName("org.apache.aries.blueprint.testbundles");
+        assertNotNull(bundles);
+        bundles.start();
+
+        Thread.sleep(500); //allow registration to happen
+
+        //Asserting NS blacklisting
+        assertEquals(1, Arrays.stream(bundles.getRegisteredServices()).filter(sr -> sr.getProperty("osgi.service.blueprint.namespace") != null).count());
+        assertTrue(Arrays.stream(bundles.getRegisteredServices()).anyMatch(sr -> sr.getProperty("osgi.service.blueprint.namespace").equals("http://www.springframework.org/schema/good")));
+    }
+
     @org.ops4j.pax.exam.Configuration
     public Option[] configuration() {
         return new Option[] {
             baseOptions(),
             Helper.blueprintBundles(),
+            newConfiguration(Activator.SPRING_NAMESPACE_BLACKLIST_PID).put("http://www.springframework.org/schema/bad", "org.apache.aries.blueprint.testbundles.TestNamespaceHandler").asOption(),
             // Blueprint spring
             mvnBundle("org.apache.aries.blueprint", "org.apache.aries.blueprint.spring"),
             // Spring

--- a/blueprint/itests/blueprint-testbundles/src/main/java/org/apache/aries/blueprint/testbundles/TestNamespaceHandler.java
+++ b/blueprint/itests/blueprint-testbundles/src/main/java/org/apache/aries/blueprint/testbundles/TestNamespaceHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.aries.blueprint.testbundles;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.xml.NamespaceHandler;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+public class TestNamespaceHandler implements NamespaceHandler {
+    @Override
+    public void init() {
+
+    }
+
+    @Override
+    public BeanDefinition parse(Element element, ParserContext parserContext) {
+        return null;
+    }
+
+    @Override
+    public BeanDefinitionHolder decorate(Node node, BeanDefinitionHolder beanDefinitionHolder, ParserContext parserContext) {
+        return null;
+    }
+}

--- a/blueprint/itests/blueprint-testbundles/src/main/resources/META-INF/spring.handlers
+++ b/blueprint/itests/blueprint-testbundles/src/main/resources/META-INF/spring.handlers
@@ -1,0 +1,21 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+http\://www.springframework.org/schema/bad=org.apache.aries.blueprint.testbundles.TestNamespaceHandler
+http\://www.springframework.org/schema/good=org.apache.aries.blueprint.testbundles.TestNamespaceHandler

--- a/blueprint/itests/blueprint-testbundles/src/main/resources/META-INF/spring.schemas
+++ b/blueprint/itests/blueprint-testbundles/src/main/resources/META-INF/spring.schemas
@@ -1,0 +1,21 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+http\://www.springframework.org/schema/bad.xsd=/does/not/exist
+http\://www.springframework.org/schema/good.xsd=/does/not/exist


### PR DESCRIPTION
This functionality is needed for example to bring back camel 3 spring support. 
In order for this to happen we 1st need to block original camel spring namespace handler and register one which is osgi capable. We still need however camel spring project itself to run spring camel context and standard spring features like properties registration or transactions.
Also since camel 3 osgi support is now part of separate repository and there is no appetite from community to make the main camel repo osgi capable- therefore this change.