### PR TITLE
Update to asm 9 for compatibility

### DIFF
--- a/spi-fly/spi-fly-weaver/src/main/java/org/apache/aries/spifly/weaver/TCCLSetterVisitor.java
+++ b/spi-fly/spi-fly-weaver/src/main/java/org/apache/aries/spifly/weaver/TCCLSetterVisitor.java
@@ -64,7 +64,7 @@ public class TCCLSetterVisitor extends ClassVisitor implements Opcodes {
     private boolean woven = false;
 
     public TCCLSetterVisitor(ClassVisitor cv, String className, Set<WeavingData> weavingData) {
-        super(Opcodes.ASM7, cv);
+        super(Opcodes.ASM9, cv);
         this.targetClass = Type.getType("L" + className.replace('.', '/') + ";");
         this.weavingData = weavingData;
     }


### PR DESCRIPTION
Updated the `asm opcode` to `9` in the `TCCLSetterVisitor` constructor to avoid `UnsupportedOperationException` thrown by asm `ClassVisitor` baseclass, see JIRA https://issues.apache.org/jira/browse/ARIES-2080.  As `spifly` has a hard dependency on `asm` version minimum `9.3`, the opcode argument should probably have been upgraded when the `asm` dependency was upgraded to `9.3`.