### PR TITLE
[ARIES-2108] Catch 'NoClassDefFoundError' when loading Service-Provider instances

### DIFF
--- a/spi-fly/spi-fly-core/src/main/java/org/apache/aries/spifly/ProviderBundleTrackerCustomizer.java
+++ b/spi-fly/spi-fly-core/src/main/java/org/apache/aries/spifly/ProviderBundleTrackerCustomizer.java
@@ -172,7 +172,7 @@ public class ProviderBundleTrackerCustomizer implements BundleTrackerCustomizer 
 
                 activator.registerProviderBundle(details.serviceType, bundle, details.properties);
                 log(Level.INFO, "Registered provider " + details.instanceType + " of service " + details.serviceType + " in bundle " + bundle.getSymbolicName());
-            } catch (Exception e) {
+            } catch (Exception | NoClassDefFoundError e) {
                 log(Level.FINE,
                     "Could not load provider " + details.instanceType + " of service " + details.serviceType, e);
             }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/ARIES-2108.

Loading ServiceProvider instances, which depend on classes absent at runtime (e.g. because they are contained in an optional dependency) throws a `NoClassDefFoundError` instead of a `ClassNotFoundException`,  which is propagated to the caller of `ProviderBundleTrackerCustomizer.addingBundle()` and leads to an empty list of providers. Instead a `NoClassDefFoundError` should be handled like a `ClassNotFoundException`.

The reason for this different exception in this case is that although the service class is found it cannot be defined.

The javadoc of `NoClassDefFoundError` states:
```
Thrown if the Java Virtual Machine or a ClassLoader instance tries to load in the definition of a class
(as part of a normal method call or as part of creating a new instance using the new expression)
and no definition of the class could be found.
```

The javadoc of `ClassNotFoundException` states:
```
Thrown when an application tries to load in a class through its string name using:
- The forName method in class Class.
- The findSystemClass method in class ClassLoader .
- The loadClass method in class ClassLoader.
but no definition for the class with the specified name could be found.
```

One example where this scenario occurs is Logback for SLF4J-2. Besides the `SLF4JServiceProvider` service this bundle also provides a `ServletContainerInitializer`, which is only relevant/intended for server/web-app environments where an implementation of the `jakarta./javax.servlet` API is provided.
Therefore the maven dependencies for `jakarta./javax.servlet` are in the provided scope and optional and correspondingly the `jakarta./javax.servlet` packages are only optionally imported in the `MANIFEST.MF`.

https://github.com/qos-ch/logback/blob/4e069d34d9422a43511ae7d6242a27caa8834e14/logback-classic/pom.xml#L335-L356