### PR TITLE
Allow for BREE JavaSE > 9 (e.g. 'JavaSE-9')

### DIFF
--- a/subsystem/subsystem-core/src/main/java/org/apache/aries/subsystem/core/archive/Grammar.java
+++ b/subsystem/subsystem-core/src/main/java/org/apache/aries/subsystem/core/archive/Grammar.java
@@ -76,7 +76,7 @@ public interface Grammar {
 	public static final String DIGIT = "[0-9]";
 	public static final String ALPHA = "[A-Za-z]";
 	public static final String ALPHANUM = DIGIT + '|' + ALPHA;
-	public static final String TOKEN = "(?:" + ALPHANUM + "|_|-)+";
+	public static final String TOKEN = "(?:" + ALPHANUM + "|_|-)+?";
 	public static final String EXTENDED = "(?:" + ALPHANUM + "|_|-|\\.)+";
 	public static final String QUOTED_STRING = "\"(?:[^\\\\\"\r\n\u0000]|\\\\\"|\\\\\\\\)*\"";
 	public static final String ARGUMENT = EXTENDED + '|' + QUOTED_STRING;

--- a/subsystem/subsystem-core/src/test/java/org/apache/aries/subsystem/core/archive/BundleRequiredExecutionEnvironmentHeaderTest.java
+++ b/subsystem/subsystem-core/src/test/java/org/apache/aries/subsystem/core/archive/BundleRequiredExecutionEnvironmentHeaderTest.java
@@ -114,7 +114,8 @@ public class BundleRequiredExecutionEnvironmentHeaderTest {
 	public void testParser4() {
 		doTestParser("JavaSE-1.6", "JavaSE", "1.6");
 	}
-	
+
+
 	@Test
 	public void testParser5() {
 		doTestParser("AA/BB-1.7", "AA/BB", "1.7");
@@ -129,6 +130,22 @@ public class BundleRequiredExecutionEnvironmentHeaderTest {
 	public void testParser7() {
 		doTestParser("MyEE-badVersion", "MyEE-badVersion", (Version)null);
 	}
+
+	@Test
+	public void testParser8() {
+		doTestParser("JavaSE-9", "JavaSE", "9");
+	}
+
+	@Test
+	public void testParser9() {
+		doTestParser("JavaSE-10", "JavaSE", "10");
+	}
+
+	@Test
+	public void testParser10() {
+		doTestParser("JavaSE-17", "JavaSE", "17");
+	}
+	
 	
 	private void assertClause(BundleRequiredExecutionEnvironmentHeader.Clause clause, String clauseStr, String name, String version, String filter) {
 		assertClause(clause, clauseStr, name, Version.parseVersion(version), filter);


### PR DESCRIPTION
BREE parser fixed to recognize latest JavaSE