### PR TITLE
Static weaving version mismatch

### DIFF
--- a/spi-fly/pom.xml
+++ b/spi-fly/pom.xml
@@ -154,6 +154,11 @@
                         </includes>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>properties-maven-plugin</artifactId>
+                    <version>1.2.1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>

--- a/spi-fly/spi-fly-static-bundle/pom.xml
+++ b/spi-fly/spi-fly-static-bundle/pom.xml
@@ -79,6 +79,24 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <files>
+                                <file>../spi-fly-core/src/main/resources/org/apache/aries/spifly/packageinfo</file>
+                            </files>
+                            <keyPrefix>spiFlyPackage.</keyPrefix>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
                 <version>${bnd.version}</version>
@@ -86,7 +104,7 @@
                     <bnd><![CDATA[
                     Bundle-Activator: org.apache.aries.spifly.staticbundle.StaticWeavingActivator
                     Export-Package: \
-                        org.apache.aries.spifly.*;version=${project.version}
+                        org.apache.aries.spifly.*;version=${spiFlyPackage.version}
                     -conditionalpackage: \
                         aQute.bnd.exceptions,\
                         aQute.bnd.header,\


### PR DESCRIPTION
I was trying out the SPI Fly static weaving method but I ran into an issue: the processed bundle would declare a dependency on the `org.apache.aries.spifly` package with version specification `[1.1.0,1.2.0)` (meaning `1.1.x` is allowed).

The static weaving tool I was using was at version 1.3.7 (the latest available) and I assumed the static weaving bundle should be at the same version. Since this is newer than 1.1.x, the dependency is never satisfied.

This PR ensures the `Export-Package` version of the static weaving bundle is read from the same `packageinfo` file that the tool uses for the `Import-Package` instruction of the weaved bundle.