### PR TITLE
jmx: use Aries parent 2.1.1

### DIFF
--- a/jmx/jmx-parent/pom.xml
+++ b/jmx/jmx-parent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.aries</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.1</version>
+        <version>2.1.1</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This adapts to the latest changes and switched the Java compiler to Java 8, which is a reasonable setting these days.