### PR TITLE
[ARIES-2161] Update destroy method to be compatible with spring 5 and 6

### DIFF
--- a/blueprint/blueprint-spring-extender/pom.xml
+++ b/blueprint/blueprint-spring-extender/pom.xml
@@ -73,7 +73,7 @@
         <org.osgi.compendium.version>4.3.1</org.osgi.compendium.version>
         <pax-swissbox-tinybundles.version>1.3.1</pax-swissbox-tinybundles.version>
         <slf4j.version>1.7.5</slf4j.version>
-        <spring.version>4.2.2.RELEASE</spring.version>
+        <spring.version>5.3.39</spring.version>
     </properties>
 
     <profiles>

--- a/blueprint/blueprint-spring-extender/src/test/java/org/apache/aries/blueprint/spring/extender/SpringXsdVersionResolverTest.java
+++ b/blueprint/blueprint-spring-extender/src/test/java/org/apache/aries/blueprint/spring/extender/SpringXsdVersionResolverTest.java
@@ -30,6 +30,6 @@ public class SpringXsdVersionResolverTest {
     public void testResolve() {
         final String xsdVersion = SpringXsdVersionResolver.resolve();
 
-        Assert.assertThat(xsdVersion, equalTo("4.2"));
+        Assert.assertThat(xsdVersion, equalTo("5.3"));
     }
 }

--- a/blueprint/blueprint-spring/pom.xml
+++ b/blueprint/blueprint-spring/pom.xml
@@ -71,7 +71,7 @@
         <org.apache.felix.utils.version>1.11.6</org.apache.felix.utils.version>
         <pax-swissbox-tinybundles.version>1.3.1</pax-swissbox-tinybundles.version>
         <slf4j.version>1.7.5</slf4j.version>
-        <spring.version>4.2.2.RELEASE</spring.version>
+        <spring.version>5.3.39</spring.version>
     </properties>
 
     <profiles>

--- a/blueprint/blueprint-spring/src/main/java/org/apache/aries/blueprint/spring/BlueprintBeanFactory.java
+++ b/blueprint/blueprint-spring/src/main/java/org/apache/aries/blueprint/spring/BlueprintBeanFactory.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanNotOfRequiredTypeException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.core.ResolvableType;
@@ -232,6 +233,16 @@ public class BlueprintBeanFactory extends DefaultListableBeanFactory implements 
         }
 
         @Override
+        public <T> ObjectProvider<T> getBeanProvider(Class<T> requiredType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> ObjectProvider<T> getBeanProvider(ResolvableType requiredType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public boolean containsBean(String name) {
             return container.getComponentIds().contains(name);
         }
@@ -258,6 +269,11 @@ public class BlueprintBeanFactory extends DefaultListableBeanFactory implements 
 
         @Override
         public Class<?> getType(String name) throws NoSuchBeanDefinitionException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Class<?> getType(String name, boolean allowFactoryBeanInit) throws NoSuchBeanDefinitionException {
             throw new UnsupportedOperationException();
         }
 

--- a/blueprint/blueprint-spring/src/main/java/org/apache/aries/blueprint/spring/BlueprintNamespaceHandler.java
+++ b/blueprint/blueprint-spring/src/main/java/org/apache/aries/blueprint/spring/BlueprintNamespaceHandler.java
@@ -147,7 +147,7 @@ public class BlueprintNamespaceHandler implements NamespaceHandler, NamespaceHan
         if (applicationContext == null) {
             applicationContext = new SpringApplicationContext(container);
             registry.registerComponentDefinition(createPassThrough(parserContext,
-                    SPRING_APPLICATION_CONTEXT_ID, applicationContext, "destroy"
+                    SPRING_APPLICATION_CONTEXT_ID, applicationContext, "close"
             ));
         }
         // Create registry


### PR DESCRIPTION
Problem found : the class `SpringApplicationContext` inherits from `org.springframework.context.support.AbstractApplicationContext` , which had a `destroy` method in version 4, but was deprecated then removed in the version 6 of spring framework.

The name of the destroy method must be updated to match this new name