### PR TITLE
[ARIES-2163] Replace ianal-maven-plugin with geronimo tools-maven-plugin

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 11 ]
+        java: [ 8, 11, 17, 21 ]
         os: [ ubuntu-latest ]
     name: JDK${{ matrix.java }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>30</version>
+        <version>33</version>
         <relativePath/>
     </parent>
 
@@ -233,11 +233,11 @@
         <maven-paxexam-plugin.version>1.2.4</maven-paxexam-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <org.apache.aries.versioning.plugin.version>0.3.0</org.apache.aries.versioning.plugin.version>
-        <ianal-maven-plugin.version>1.0-alpha-1</ianal-maven-plugin.version>
         <animal-sniffer-enforcer-rule.version>1.6</animal-sniffer-enforcer-rule.version>
+        <tools-maven-plugin.version>1.4</tools-maven-plugin.version>
 
         <!--Other-->
-        <java.source.version>1.8</java.source.version>
+        <java.source.version>8</java.source.version>
     </properties>
 
     <build>
@@ -454,12 +454,12 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <optimize>true</optimize>
                         <debug>true</debug>
                         <showDeprecation>true</showDeprecation>
                         <showWarnings>true</showWarnings>
                         <source>${java.source.version}</source>
                         <target>${java.source.version}</target>
+                        <release>${java.source.version}</release>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -533,9 +533,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>ianal-maven-plugin</artifactId>
-                <version>${ianal-maven-plugin.version}</version>
+                <groupId>org.apache.geronimo.genesis.plugins</groupId>
+                <artifactId>tools-maven-plugin</artifactId>
+                <version>${tools-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>30</version>
+        <version>33</version>
     </parent>
 
     <!-- This pom is for convenience in building several aries subprojects at once.

--- a/versioning/pom.xml
+++ b/versioning/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.aries</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.2-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/versioning/versioning-checker/pom.xml
+++ b/versioning/versioning-checker/pom.xml
@@ -24,8 +24,8 @@
     <parent>
         <groupId>org.apache.aries</groupId>
         <artifactId>parent</artifactId>
-        <version>2.1.1</version>
-        <relativePath/>
+        <version>2.1.2-SNAPSHOT</version>
+        <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>org.apache.aries.versioning</groupId>

--- a/versioning/versioning-plugin/pom.xml
+++ b/versioning/versioning-plugin/pom.xml
@@ -24,8 +24,8 @@
     <parent>
         <groupId>org.apache.aries</groupId>
         <artifactId>parent</artifactId>
-        <version>2.1.1</version>
-        <relativePath/>
+        <version>2.1.2-SNAPSHOT</version>
+        <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <groupId>org.apache.aries.versioning</groupId>


### PR DESCRIPTION
ianal-maven-plugin does not support Java 17 and above. geronimo tools-maven-plugin may be used instead with minimal configuration as implemented also in https://issues.apache.org/jira/browse/AMQ-9065 and https://issues.apache.org/jira/browse/SLING-10053 