### PR TITLE
[MAINTENANCE] Updater pax-web to 8.x in jndi

### DIFF
--- a/jndi/jndi-url-itest/pom.xml
+++ b/jndi/jndi-url-itest/pom.xml
@@ -47,7 +47,7 @@
         <cm.version>3.2.0-v20070116</cm.version>
         <depends-maven-plugin.version>1.5.0</depends-maven-plugin.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-        <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
+        <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>
         <jndi-api.version>${jndi-api.dev-version}</jndi-api.version>
         <jndi-bundle.version>${jndi-bundle.dev-version}</jndi-bundle.version>
         <jndi-url-itest-biz.version>${jndi-url-itest-biz.dev-version}</jndi-url-itest-biz.version>
@@ -281,9 +281,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>${javax.servlet-api.version}</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>${jakarta.servlet-api.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jndi/jndi-url-itest/pom.xml
+++ b/jndi/jndi-url-itest/pom.xml
@@ -46,7 +46,8 @@
         <asm-debug-all.version>5.0.3</asm-debug-all.version>
         <cm.version>3.2.0-v20070116</cm.version>
         <depends-maven-plugin.version>1.5.0</depends-maven-plugin.version>
-        <geronimo-servlet_3.0_spec.version>1.0</geronimo-servlet_3.0_spec.version>
+        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
+        <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <jndi-api.version>${jndi-api.dev-version}</jndi-api.version>
         <jndi-bundle.version>${jndi-bundle.dev-version}</jndi-bundle.version>
         <jndi-url-itest-biz.version>${jndi-url-itest-biz.dev-version}</jndi-url-itest-biz.version>
@@ -59,7 +60,7 @@
         <org.eclipse.osgi.version>3.22.0</org.eclipse.osgi.version>
         <pax-exam.version>4.13.0</pax-exam.version>
         <pax-url.version>2.6.16</pax-url.version>
-        <pax-web.version>6.1.2</pax-web.version>
+        <pax-web.version>8.0.30</pax-web.version>
         <services.version>3.2.100.v20100503</services.version>
         <slf4j-api.version>1.7.7</slf4j-api.version>
         <tinybundles.version>2.0.0</tinybundles.version>
@@ -238,13 +239,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-servlet_3.0_spec</artifactId>
-            <scope>test</scope>
-            <version>${geronimo-servlet_3.0_spec.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.ops4j.pax.web</groupId>
             <artifactId>pax-web-extender-war</artifactId>
             <scope>test</scope>
@@ -252,7 +246,7 @@
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.web</groupId>
-            <artifactId>pax-web-jetty-bundle</artifactId>
+            <artifactId>pax-web-tomcat-bundle</artifactId>
             <scope>test</scope>
             <version>${pax-web.version}</version>
         </dependency>
@@ -265,12 +259,6 @@
         <dependency>
             <groupId>org.ops4j.pax.web</groupId>
             <artifactId>pax-web-spi</artifactId>
-            <scope>test</scope>
-            <version>${pax-web.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.ops4j.pax.web</groupId>
-            <artifactId>pax-web-descriptor</artifactId>
             <scope>test</scope>
             <version>${pax-web.version}</version>
         </dependency>
@@ -290,6 +278,18 @@
             <groupId>org.apache.xbean</groupId>
             <artifactId>xbean-bundleutils</artifactId>
             <version>${xbean.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${javax.servlet-api.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax.annotation-api.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/jndi/jndi-url-itest/src/test/java/org/apache/aries/jndi/itests/JndiUrlIntegrationTest.java
+++ b/jndi/jndi-url-itest/src/test/java/org/apache/aries/jndi/itests/JndiUrlIntegrationTest.java
@@ -151,13 +151,13 @@ public class JndiUrlIntegrationTest extends AbstractIntegrationTest {
                 // Bundles
                 mavenBundle("org.eclipse.equinox", "cm").versionAsInProject(),
                 mavenBundle("org.eclipse.osgi", "org.eclipse.osgi.services").versionAsInProject(),
-                mavenBundle("org.apache.geronimo.specs", "geronimo-servlet_3.0_spec").versionAsInProject(),
+                mavenBundle("javax.servlet", "javax.servlet-api").versionAsInProject(),
+                mavenBundle("javax.annotation", "javax.annotation-api").versionAsInProject(),
 
                 mavenBundle("org.ops4j.pax.web", "pax-web-extender-war").versionAsInProject(),
-                mavenBundle("org.ops4j.pax.web", "pax-web-jetty-bundle").versionAsInProject(),
+                mavenBundle("org.ops4j.pax.web", "pax-web-tomcat-bundle").versionAsInProject(),
                 mavenBundle("org.ops4j.pax.web", "pax-web-api").versionAsInProject(),
                 mavenBundle("org.ops4j.pax.web", "pax-web-spi").versionAsInProject(),
-                mavenBundle("org.ops4j.pax.web", "pax-web-descriptor").versionAsInProject(),
                 mavenBundle("org.apache.xbean", "xbean-finder-shaded").versionAsInProject(),
                 mavenBundle("org.apache.xbean", "xbean-asm9-shaded").versionAsInProject(),
                 mavenBundle("org.apache.xbean", "xbean-bundleutils").versionAsInProject(),

--- a/jndi/jndi-url-itest/src/test/java/org/apache/aries/jndi/itests/JndiUrlIntegrationTest.java
+++ b/jndi/jndi-url-itest/src/test/java/org/apache/aries/jndi/itests/JndiUrlIntegrationTest.java
@@ -151,7 +151,7 @@ public class JndiUrlIntegrationTest extends AbstractIntegrationTest {
                 // Bundles
                 mavenBundle("org.eclipse.equinox", "cm").versionAsInProject(),
                 mavenBundle("org.eclipse.osgi", "org.eclipse.osgi.services").versionAsInProject(),
-                mavenBundle("javax.servlet", "javax.servlet-api").versionAsInProject(),
+                mavenBundle("jakarta.servlet", "jakarta.servlet-api").versionAsInProject(),
                 mavenBundle("javax.annotation", "javax.annotation-api").versionAsInProject(),
 
                 mavenBundle("org.ops4j.pax.web", "pax-web-extender-war").versionAsInProject(),


### PR DESCRIPTION
- [x] new pax-web-extender rely on tomcat so it's easier to switch to pax-web-tomcat-bundle but during itests Tomcat stucks in starting:
```
[paxweb-config-1-thread-1 (change controller)] INFO org.ops4j.pax.web.service.tomcat.internal.PaxWebHttp11Nio2Protocol - The ["http-nio2-0.0.0.0-8080"] connector has been configured to support HTTP upgrade to [h2c]
[paxweb-config-1-thread-1 (change controller)] INFO org.ops4j.pax.web.service.tomcat.internal.PaxWebHttp11Nio2Protocol - Initializing ProtocolHandler ["http-nio2-0.0.0.0-8080"]
[paxweb-config-1-thread-1 (change controller)] INFO org.apache.catalina.core.StandardService - Starting service [Catalina]
[paxweb-config-1-thread-1 (change controller)] INFO org.apache.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/9.0.98]
```