### PR TITLE
[MAINTENANCE] Update pax-exam in ejb

### DIFF
--- a/ejb/ejb-modeller-itest/pom.xml
+++ b/ejb/ejb-modeller-itest/pom.xml
@@ -47,7 +47,7 @@
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.17.0</commons-lang3.version>
         <depends-maven-plugin.version>1.5.0</depends-maven-plugin.version>
-        <exam.version>3.4.0</exam.version>
+        <exam.version>4.13.5</exam.version>
         <geronimo-activation_1.1_spec.version>1.1</geronimo-activation_1.1_spec.version>
         <geronimo-annotation_1.1_spec.version>1.0.1</geronimo-annotation_1.1_spec.version>
         <geronimo-ejb_3.1_spec.version>1.0.2</geronimo-ejb_3.1_spec.version>
@@ -87,7 +87,7 @@
         <org.apache.servicemix.bundles.javassist.version>3.12.1.GA_3</org.apache.servicemix.bundles.javassist.version>
         <org.apache.servicemix.bundles.jaxb-impl.version>2.2.1.1_2</org.apache.servicemix.bundles.jaxb-impl.version>
         <org.apache.servicemix.bundles.wsdl4j-1.6.1.version>4.0-m1</org.apache.servicemix.bundles.wsdl4j-1.6.1.version>
-        <org.eclipse.osgi.version>3.11.3</org.eclipse.osgi.version>
+        <org.eclipse.osgi.version>3.22.0</org.eclipse.osgi.version>
         <scannotation.version>1.0.2_1</scannotation.version>
         <tinybundles.version>2.0.0</tinybundles.version>
         <url.version>2.6.16</url.version>
@@ -480,7 +480,7 @@
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
-            <artifactId>pax-exam-container-forked</artifactId>
+            <artifactId>pax-exam-container-native</artifactId>
             <version>${exam.version}</version>
             <scope>test</scope>
         </dependency>

--- a/ejb/openejb-extender-itest/pom.xml
+++ b/ejb/openejb-extender-itest/pom.xml
@@ -91,9 +91,9 @@
         <org.apache.servicemix.bundles.jaxb-impl.version>2.2.1.1_2</org.apache.servicemix.bundles.jaxb-impl.version>
         <org.apache.servicemix.bundles.serp.version>1.13.1_2</org.apache.servicemix.bundles.serp.version>
         <org.apache.servicemix.bundles.wsdl4j-1.6.1.version>4.0-m1</org.apache.servicemix.bundles.wsdl4j-1.6.1.version>
-        <org.eclipse.osgi.version>3.11.3</org.eclipse.osgi.version>
+        <org.eclipse.osgi.version>3.22.0</org.eclipse.osgi.version>
         <org.osgi.enterprise.version>4.2.0</org.osgi.enterprise.version>
-        <pax-exam.version>3.4.0</pax-exam.version>
+        <pax-exam.version>4.13.3</pax-exam.version>
         <pax-logging-api.version>1.7.2</pax-logging-api.version>
         <pax-logging-service.version>1.7.2</pax-logging-service.version>
         <pax-url-aether.version>2.6.16</pax-url-aether.version>
@@ -102,12 +102,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.enterprise</artifactId>
-            <version>${org.osgi.enterprise.version}</version>
-        </dependency>
-
         <!-- framework -->
         <dependency>
             <groupId>org.eclipse.platform</groupId>
@@ -119,6 +113,11 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.enterprise</artifactId>
+            <version>${org.osgi.enterprise.version}</version>
         </dependency>
 
         <!-- logging -->

--- a/ejb/openejb-extender-itest/src/test/java/org/apache/aries/ejb/openejb/extender/itest/AbstractOpenEJBTest.java
+++ b/ejb/openejb-extender-itest/src/test/java/org/apache/aries/ejb/openejb/extender/itest/AbstractOpenEJBTest.java
@@ -24,17 +24,16 @@ import java.util.zip.ZipOutputStream;
 
 import org.apache.aries.itest.AbstractIntegrationTest;
 import org.apache.aries.util.io.IOUtils;
-import org.ops4j.pax.exam.Configuration;
+
 import org.ops4j.pax.exam.Option;
 
 public abstract class AbstractOpenEJBTest extends AbstractIntegrationTest {
 
-    @Configuration
-    public static Option[] configuration() {
-        return options(
+    public static Option baseConfiguration() {
+        return composite(
                 junitBundles(),
-                mavenBundle("org.ops4j.pax.logging", "pax-logging-api", "1.7.2"),
-                mavenBundle("org.ops4j.pax.logging", "pax-logging-service", "1.7.2"),
+                mavenBundle("org.ops4j.pax.logging", "pax-logging-api").versionAsInProject(),
+                mavenBundle("org.ops4j.pax.logging", "pax-logging-service").versionAsInProject(),
 
                 frameworkProperty("org.osgi.framework.system.packages")
                         .value("javax.accessibility,javax.activation,javax.activity,javax.annotation,javax.annotation.processing,javax.crypto,javax.crypto.interfaces,javax.crypto.spec,javax.imageio,javax.imageio.event,javax.imageio.metadata,javax.imageio.plugins.bmp,javax.imageio.plugins.jpeg,javax.imageio.spi,javax.imageio.stream,javax.jws,javax.jws.soap,javax.lang.model,javax.lang.model.element,javax.lang.model.type,javax.lang.model.util,javax.management,javax.management.loading,javax.management.modelmbean,javax.management.monitor,javax.management.openmbean,javax.management.relation,javax.management.remote,javax.management.remote.rmi,javax.management.timer,javax.naming,javax.naming.directory,javax.naming.event,javax.naming.ldap,javax.naming.spi,javax.net,javax.net.ssl,javax.print,javax.print.attribute,javax.print.attribute.standard,javax.print.event,javax.rmi,javax.rmi.CORBA,javax.rmi.ssl,javax.script,javax.security.auth,javax.security.auth.callback,javax.security.auth.kerberos,javax.security.auth.login,javax.security.auth.spi,javax.security.auth.x500,javax.security.cert,javax.security.sasl,javax.sound.midi,javax.sound.midi.spi,javax.sound.sampled,javax.sound.sampled.spi,javax.sql,javax.sql.rowset,javax.sql.rowset.serial,javax.sql.rowset.spi,javax.swing,javax.swing.border,javax.swing.colorchooser,javax.swing.event,javax.swing.filechooser,javax.swing.plaf,javax.swing.plaf.basic,javax.swing.plaf.metal,javax.swing.plaf.multi,javax.swing.plaf.synth,javax.swing.table,javax.swing.text,javax.swing.text.html,javax.swing.text.html.parser,javax.swing.text.rtf,javax.swing.tree,javax.swing.undo,javax.tools,javax.xml,javax.xml.bind,javax.xml.bind.annotation,javax.xml.bind.annotation.adapters,javax.xml.bind.attachment,javax.xml.bind.helpers,javax.xml.bind.util,javax.xml.crypto,javax.xml.crypto.dom,javax.xml.crypto.dsig,javax.xml.crypto.dsig.dom,javax.xml.crypto.dsig.keyinfo,javax.xml.crypto.dsig.spec,javax.xml.datatype,javax.xml.namespace,javax.xml.parsers,javax.xml.soap,javax.xml.stream,javax.xml.stream.events,javax.xml.stream.util,javax.xml.transform,javax.xml.transform.dom,javax.xml.transform.sax,javax.xml.transform.stax,javax.xml.transform.stream,javax.xml.validation,javax.xml.ws,javax.xml.ws.handler,javax.xml.ws.handler.soap,javax.xml.ws.http,javax.xml.ws.soap,javax.xml.ws.spi,javax.xml.xpath,org.ietf.jgss,org.omg.CORBA,org.omg.CORBA.DynAnyPackage,org.omg.CORBA.ORBPackage,org.omg.CORBA.TypeCodePackage,org.omg.CORBA.portable,org.omg.CORBA_2_3,org.omg.CORBA_2_3.portable,org.omg.CosNaming,org.omg.CosNaming.NamingContextExtPackage,org.omg.CosNaming.NamingContextPackage,org.omg.Dynamic,org.omg.DynamicAny,org.omg.DynamicAny.DynAnyFactoryPackage,org.omg.DynamicAny.DynAnyPackage,org.omg.IOP,org.omg.IOP.CodecFactoryPackage,org.omg.IOP.CodecPackage,org.omg.Messaging,org.omg.PortableInterceptor,org.omg.PortableInterceptor.ORBInitInfoPackage,org.omg.PortableServer,org.omg.PortableServer.CurrentPackage,org.omg.PortableServer.POAManagerPackage,org.omg.PortableServer.POAPackage,org.omg.PortableServer.ServantLocatorPackage,org.omg.PortableServer.portable,org.omg.SendingContext,org.omg.stub.java.rmi,org.w3c.dom,org.w3c.dom.bootstrap,org.w3c.dom.css,org.w3c.dom.events,org.w3c.dom.html,org.w3c.dom.ls,org.w3c.dom.ranges,org.w3c.dom.stylesheets,org.w3c.dom.traversal,org.w3c.dom.views,org.xml.sax,org.xml.sax.ext,org.xml.sax.helpers"),

--- a/ejb/openejb-extender-itest/src/test/java/org/apache/aries/ejb/openejb/extender/itest/AdvancedEJBBundleTest.java
+++ b/ejb/openejb-extender-itest/src/test/java/org/apache/aries/ejb/openejb/extender/itest/AdvancedEJBBundleTest.java
@@ -55,8 +55,9 @@ import beans.jpa.Laptop;
 public class AdvancedEJBBundleTest extends AbstractOpenEJBTest {
 
     @Configuration
-    public static Option[] jpaConfig() {
+    public Option[] jpaConfig() {
         return options(
+                baseConfiguration(),
                 mavenBundle("org.apache.derby", "derby").versionAsInProject(),
                 mavenBundle("org.apache.aries.jpa", "org.apache.aries.jpa.api").versionAsInProject(),
                 mavenBundle("org.apache.aries.jpa", "org.apache.aries.jpa.container").versionAsInProject(),

--- a/ejb/openejb-extender-itest/src/test/java/org/apache/aries/ejb/openejb/extender/itest/EJBBundleTest.java
+++ b/ejb/openejb-extender-itest/src/test/java/org/apache/aries/ejb/openejb/extender/itest/EJBBundleTest.java
@@ -18,6 +18,7 @@ package org.apache.aries.ejb.openejb.extender.itest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -25,6 +26,8 @@ import java.util.zip.ZipOutputStream;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
@@ -38,6 +41,13 @@ import beans.xml.RemoteIface;
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class EJBBundleTest extends AbstractOpenEJBTest {
+
+    @Configuration
+    public Option[] configuration() {
+        return options(
+                baseConfiguration()
+        );
+    }
 
     private void assertXML(Bundle test, boolean exists) throws Exception {
         ServiceReference[] local = context().getAllServiceReferences(LocalIface.class.getName(),


### PR DESCRIPTION
EJB extender itest has dependency upgraded only to 4.13.3 since there are problem with duplicated installation of geronimo atinject