### PR TITLE
[MAINTENANCE] Bump eclipse to 3.15.300 in blueprint itests

### DIFF
--- a/blueprint/itests/blueprint-itests/pom.xml
+++ b/blueprint/itests/blueprint-itests/pom.xml
@@ -62,7 +62,7 @@
         <org.apache.felix.configadmin.version>1.8.0</org.apache.felix.configadmin.version>
         <org.apache.servicemix.bundles.aopalliance.version>1.0_6</org.apache.servicemix.bundles.aopalliance.version>
         <org.apache.servicemix.bundles.spring.version>5.3.39_1</org.apache.servicemix.bundles.spring.version>
-        <org.eclipse.osgi.version>3.11.3</org.eclipse.osgi.version>
+        <org.eclipse.osgi.version>3.15.300</org.eclipse.osgi.version>
         <pax-exam.version>4.13.5</pax-exam.version>
         <pax-tinybundles.version>2.0.0</pax-tinybundles.version>
         <pax-url.version>2.6.16</pax-url.version>


### PR DESCRIPTION
This version is the last supporting Java 7 and at least one of the used bundle still needs it