### PR TITLE
[MAINTENANCE] Do not run blueprint plugin in blueprint workflow

### DIFF
--- a/.github/workflows/blueprint-plugin.yml
+++ b/.github/workflows/blueprint-plugin.yml
@@ -11,7 +11,6 @@
 #    limitations under the License.
 
 name: Blueprint Plugin - CI Build
-# TODO ARIES-2165 remove the workflow when whole blueprint supports java 11, 17 and 21
 
 on:
   pull_request:

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -22,6 +22,7 @@ on:
       - quiesce/**
       - blueprint/**
       - .github/workflows/blueprint.yml
+      - '!blueprint/plugin/**'
   push:
     branches:
       - 'trunk'

--- a/blueprint/pom.xml
+++ b/blueprint/pom.xml
@@ -55,7 +55,6 @@
         <module>blueprint-spring</module>
         <module>blueprint-spring-extender</module>
         <module>blueprint-spring-camel</module>
-        <module>plugin</module>
         <module>examples</module>
         <module>itests</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <module>application</module>
         <module>async</module>
         <module>blueprint</module>
+        <module>blueprint/plugin</module>
         <module>eba-maven-plugin</module>
         <module>ejb</module>
         <module>esa-ant-task</module>


### PR DESCRIPTION
It will speed up blueprint module tests. Blueprint maven plugin does not need blueprint per se.