### PR TITLE
[MAINTENANCE] Split bnd and bnd plugins version properties in spi-fly

### DIFF
--- a/blueprint/blueprint-repository/pom.xml
+++ b/blueprint/blueprint-repository/pom.xml
@@ -39,7 +39,7 @@
         <blueprint.api.version>1.0.1</blueprint.api.version>
         <blueprint.cm.version>1.0.9</blueprint.cm.version>
         <blueprint.core.version>1.5.0</blueprint.core.version>
-        <bnd.version>6.4.0</bnd.version>
+        <bnd-indexer-maven-plugin.version>6.4.0</bnd-indexer-maven-plugin.version>
         <org.apache.aries.proxy.api.version>1.0.1</org.apache.aries.proxy.api.version>
         <org.apache.aries.proxy.impl.version>1.0.6</org.apache.aries.proxy.impl.version>
         <org.apache.aries.util.version>1.1.3</org.apache.aries.util.version>
@@ -68,7 +68,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-indexer-maven-plugin</artifactId>
-                <version>${bnd.version}</version>
+                <version>${bnd-indexer-maven-plugin.version}</version>
                 <configuration>
                     <localURLs>${local.index.policy}</localURLs>
                     <includeTransitive>true</includeTransitive>

--- a/spi-fly/pom.xml
+++ b/spi-fly/pom.xml
@@ -53,7 +53,8 @@
         <apache-rat-plugin.version>0.16.1</apache-rat-plugin.version>
         <asm.version>9.7.1</asm.version>
         <assertj.version>3.27.3</assertj.version>
-        <bnd.version>6.4.0</bnd.version>
+        <bnd.version>6.4.1</bnd.version>
+        <bnd-maven-plugins.version>6.4.0</bnd-maven-plugins.version>
         <easymock.version>5.5.0</easymock.version>
         <felix.framework.version>7.0.5</felix.framework.version>
         <felix.log.extension.version>1.0.0</felix.log.extension.version>

--- a/spi-fly/spi-fly-dynamic-bundle/pom.xml
+++ b/spi-fly/spi-fly-dynamic-bundle/pom.xml
@@ -120,7 +120,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd.version}</version>
+                <version>${bnd-maven-plugins.version}</version>
                 <configuration>
                     <bnd><![CDATA[
                     Bundle-Activator: org.apache.aries.spifly.dynamic.DynamicWeavingActivator
@@ -164,7 +164,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-baseline-maven-plugin</artifactId>
-                <version>${bnd.version}</version>
+                <version>${bnd-maven-plugins.version}</version>
                 <configuration>
                     <includeDistributionManagement>false</includeDistributionManagement>
                     <fullReport>true</fullReport>
@@ -181,7 +181,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-resolver-maven-plugin</artifactId>
-                <version>${bnd.version}</version>
+                <version>${bnd-maven-plugins.version}</version>
                 <configuration>
                     <failOnChanges>false</failOnChanges>
                     <scopes>

--- a/spi-fly/spi-fly-dynamic-framework-extension/pom.xml
+++ b/spi-fly/spi-fly-dynamic-framework-extension/pom.xml
@@ -114,7 +114,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd.version}</version>
+                <version>${bnd-maven-plugins.version}</version>
                 <configuration>
                     <bnd><![CDATA[
                     Fragment-Host: system.bundle;extension:=framework
@@ -167,7 +167,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-baseline-maven-plugin</artifactId>
-                <version>${bnd.version}</version>
+                <version>${bnd-maven-plugins.version}</version>
                 <configuration>
                     <includeDistributionManagement>false</includeDistributionManagement>
                     <fullReport>true</fullReport>
@@ -184,7 +184,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-resolver-maven-plugin</artifactId>
-                <version>${bnd.version}</version>
+                <version>${bnd-maven-plugins.version}</version>
                 <configuration>
                     <failOnChanges>false</failOnChanges>
                     <scopes>

--- a/spi-fly/spi-fly-itests/pom.xml
+++ b/spi-fly/spi-fly-itests/pom.xml
@@ -159,7 +159,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd.version}</version>
+                <version>${bnd-maven-plugins.version}</version>
                 <configuration>
                     <bnd><![CDATA[
                         Test-Cases: ${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE;PUBLIC}
@@ -176,7 +176,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-resolver-maven-plugin</artifactId>
-                <version>${bnd.version}</version>
+                <version>${bnd-maven-plugins.version}</version>
                 <configuration>
                     <bndruns>
                         <bndrun>test.bndrun</bndrun>
@@ -202,7 +202,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-testing-maven-plugin</artifactId>
-                <version>${bnd.version}</version>
+                <version>${bnd-maven-plugins.version}</version>
                 <configuration>
                     <bndruns>
                         <bndrun>test.bndrun</bndrun>

--- a/spi-fly/spi-fly-static-bundle/pom.xml
+++ b/spi-fly/spi-fly-static-bundle/pom.xml
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd.version}</version>
+                <version>${bnd-maven-plugins.version}</version>
                 <configuration>
                     <bnd><![CDATA[
                     Bundle-Activator: org.apache.aries.spifly.staticbundle.StaticWeavingActivator
@@ -128,7 +128,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-baseline-maven-plugin</artifactId>
-                <version>${bnd.version}</version>
+                <version>${bnd-maven-plugins.version}</version>
                 <configuration>
                     <includeDistributionManagement>false</includeDistributionManagement>
                     <fullReport>true</fullReport>
@@ -145,7 +145,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-resolver-maven-plugin</artifactId>
-                <version>${bnd.version}</version>
+                <version>${bnd-maven-plugins.version}</version>
                 <configuration>
                     <failOnChanges>false</failOnChanges>
                     <scopes>


### PR DESCRIPTION
bnd libraries have available version 6.4.1 but bnd plugins have version 6.4.0 (7.x excluded as not supporting java 8)