### PR TITLE
[SPI-FLY] Add Java 25 to workflow matrix

### DIFF
--- a/.github/workflows/spi-fly.yml
+++ b/.github/workflows/spi-fly.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 11, 17, 21 ]
+        java: [ 8, 11, 17, 21, 25 ]
         os: [ ubuntu-latest ]
         include:
         - os: windows-latest


### PR DESCRIPTION
@alien11689

The SPI Fly Framework Extension currently does not work with JDK 25. The root cause appears to be the included ASM dependency, which is not compatible with JDK 25.

There is already a Dependabot pull request that upgrades ASM to a newer, compatible version, and it has been merged. However, no new SPI Fly release has been published since then, so the issue persists for users relying on official releases.

As a comparison, the Dynamic Bundle works correctly on JDK 25 when updating the ASM dependency manually. This workaround is not applicable to the Framework Extension, as it bundles the ASM dependency internally and cannot be easily overridden.

**Request**:
Please publish a new release of SPI Fly that includes the updated ASM version so the Framework Extension can be used with JDK 25.

The JDK 25 Job fails because of bnd version < 7.2